### PR TITLE
Batch save - prevent submitting fingerprints

### DIFF
--- a/dist/public/Stash Batch Save.user.js
+++ b/dist/public/Stash Batch Save.user.js
@@ -1,12 +1,12 @@
 // ==UserScript==
 // @name        Stash Batch Save
-// @namespace   https://github.com/7dJx1qP/stash-userscripts
+// @namespace   https://github.com/stg-annon/stash-userscripts
 // @description Adds a batch save button to scenes tagger
 // @version     0.6.0
 // @author      7dJx1qP
 // @match       http://localhost:9999/*
 // @grant       unsafeWindow
-// @require     https://raw.githubusercontent.com/7dJx1qP/stash-userscripts/master/src\StashUserscriptLibrary.js
+// @require     https://raw.githubusercontent.com/stg-annon/stash-userscripts/main/src\StashUserscriptLibrary.js
 // ==/UserScript==
 
 (function() {

--- a/dist/public/Stash Batch Save.user.js
+++ b/dist/public/Stash Batch Save.user.js
@@ -30,7 +30,6 @@
 
     function run() {
         if (!running) return;
-        removeFPQueue()
         const button = buttons.pop();
         stash.setProgress((maxCount - buttons.length) / maxCount * 100);
         if (button) {
@@ -75,6 +74,7 @@
 
     function start() {
         if (!confirm("Are you sure you want to batch save?")) return;
+        hideSubmitFPButton()
         btn.innerHTML = stopLabel;
         btn.classList.remove('btn-primary');
         btn.classList.add('btn-danger');
@@ -84,6 +84,7 @@
         for (const button of document.querySelectorAll('.btn.btn-primary')) {
             if (button.innerText === 'Save') {
                 buttons.push(button);
+                hideSubmitFPButton()
             }
         }
         maxCount = buttons.length;
@@ -99,6 +100,7 @@
         stash.setProgress(0);
         sceneId = null;
         stash.removeEventListener('stash:response', processSceneUpdate);
+        setTimeout(removeFPQueue, 500)
     }
 
     stash.addEventListener('tagger:mutations:header', evt => {
@@ -117,11 +119,17 @@
         btn.style.display = saveButton ? 'inline-block' : 'none';
     }
 
+    const hideSubmitFPButton = () => {
+        const submitBtn = document.querySelector(".tagger-container-header>div>div.d-flex>button.ml-1")
+        if (submitBtn) submitBtn.style.display = "none"
+    }
+
     function removeFPQueue() {
       const DBNAME = "localforage"
       const STORENAME = "keyvaluepairs"
       const KEYNAME = "tagger"
-      
+      // hide submit button
+      hideSubmitFPButton()
       const getIDBData = (transaction) => new Promise ((resolve, reject) => {
         const result = transaction
           .objectStore(STORENAME)

--- a/dist/public/Stash Batch Save.user.js
+++ b/dist/public/Stash Batch Save.user.js
@@ -2,7 +2,7 @@
 // @name        Stash Batch Save
 // @namespace   https://github.com/7dJx1qP/stash-userscripts
 // @description Adds a batch save button to scenes tagger
-// @version     0.5.2
+// @version     0.6.0
 // @author      7dJx1qP
 // @match       http://localhost:9999/*
 // @grant       unsafeWindow
@@ -30,6 +30,7 @@
 
     function run() {
         if (!running) return;
+        removeFPQueue()
         const button = buttons.pop();
         stash.setProgress((maxCount - buttons.length) / maxCount * 100);
         if (button) {
@@ -114,6 +115,39 @@
         const taggerContainer = document.querySelector('.tagger-container');
         const saveButton = getElementByXpath("//button[text()='Save']", taggerContainer);
         btn.style.display = saveButton ? 'inline-block' : 'none';
+    }
+
+    function removeFPQueue() {
+      const DBNAME = "localforage"
+      const STORENAME = "keyvaluepairs"
+      const KEYNAME = "tagger"
+      
+      const getIDBData = (transaction) => new Promise ((resolve, reject) => {
+        const result = transaction
+          .objectStore(STORENAME)
+          .get(KEYNAME)
+        result.onsuccess = event => resolve(event.target.result)
+        result.onerror = event => reject(event.target.errorCode)
+      })
+      
+      const putIDBData = (transaction, data) => new Promise ((resolve, reject) => {
+        const result = transaction
+          .objectStore(STORENAME)
+          .put(data, KEYNAME)
+        result.onsuccess = event => resolve(event.target.result)
+        result.onerror = event => reject(event.target.errorCode)
+      })
+      
+      const IDBOpenRequest = window.indexedDB.open(DBNAME)
+      IDBOpenRequest.onsuccess = async (event) => {
+        const db = event.target.result
+        const transaction = db.transaction([STORENAME], "readwrite")
+        const data = await getIDBData(transaction)
+        // remove all fingerprints in array
+        for (const arr of Object.keys(data.fingerprintQueue)) data.fingerprintQueue[arr] = []
+        // replace object
+        await putIDBData(transaction, data)
+      }
     }
 
     stash.addEventListener('tagger:mutations:searchitems', checkSaveButtonDisplay);

--- a/src/body/Stash Batch Save.user.js
+++ b/src/body/Stash Batch Save.user.js
@@ -18,7 +18,6 @@
     let sceneId = null;
 
     function run() {
-        removeFPQueue()
         if (!running) return;
         const button = buttons.pop();
         stash.setProgress((maxCount - buttons.length) / maxCount * 100);
@@ -64,6 +63,7 @@
 
     function start() {
         if (!confirm("Are you sure you want to batch save?")) return;
+        hideSubmitFPButton()
         btn.innerHTML = stopLabel;
         btn.classList.remove('btn-primary');
         btn.classList.add('btn-danger');
@@ -73,6 +73,7 @@
         for (const button of document.querySelectorAll('.btn.btn-primary')) {
             if (button.innerText === 'Save') {
                 buttons.push(button);
+                hideSubmitFPButton()
             }
         }
         maxCount = buttons.length;
@@ -88,6 +89,7 @@
         stash.setProgress(0);
         sceneId = null;
         stash.removeEventListener('stash:response', processSceneUpdate);
+        setTimeout(removeFPQueue, 500)
     }
 
     stash.addEventListener('tagger:mutations:header', evt => {
@@ -106,11 +108,17 @@
         btn.style.display = saveButton ? 'inline-block' : 'none';
     }
 
+    const hideSubmitFPButton = () => {
+        const submitBtn = document.querySelector(".tagger-container-header>div>div.d-flex>button.ml-1")
+        if (submitBtn) submitBtn.style.display = "none"
+    }
+
     function removeFPQueue() {
       const DBNAME = "localforage"
       const STORENAME = "keyvaluepairs"
       const KEYNAME = "tagger"
-      
+      // hide submit button
+      hideSubmitFPButton()
       const getIDBData = (transaction) => new Promise ((resolve, reject) => {
         const result = transaction
           .objectStore(STORENAME)

--- a/src/body/Stash Batch Save.user.js
+++ b/src/body/Stash Batch Save.user.js
@@ -18,6 +18,7 @@
     let sceneId = null;
 
     function run() {
+        removeFPQueue()
         if (!running) return;
         const button = buttons.pop();
         stash.setProgress((maxCount - buttons.length) / maxCount * 100);
@@ -103,6 +104,39 @@
         const taggerContainer = document.querySelector('.tagger-container');
         const saveButton = getElementByXpath("//button[text()='Save']", taggerContainer);
         btn.style.display = saveButton ? 'inline-block' : 'none';
+    }
+
+    function removeFPQueue() {
+      const DBNAME = "localforage"
+      const STORENAME = "keyvaluepairs"
+      const KEYNAME = "tagger"
+      
+      const getIDBData = (transaction) => new Promise ((resolve, reject) => {
+        const result = transaction
+          .objectStore(STORENAME)
+          .get(KEYNAME)
+        result.onsuccess = event => resolve(event.target.result)
+        result.onerror = event => reject(event.target.errorCode)
+      })
+      
+      const putIDBData = (transaction, data) => new Promise ((resolve, reject) => {
+        const result = transaction
+          .objectStore(STORENAME)
+          .put(data, KEYNAME)
+        result.onsuccess = event => resolve(event.target.result)
+        result.onerror = event => reject(event.target.errorCode)
+      })
+      
+      const IDBOpenRequest = window.indexedDB.open(DBNAME)
+      IDBOpenRequest.onsuccess = async (event) => {
+        const db = event.target.result
+        const transaction = db.transaction([STORENAME], "readwrite")
+        const data = await getIDBData(transaction)
+        // remove all fingerprints in array
+        for (const arr of Object.keys(data.fingerprintQueue)) data.fingerprintQueue[arr] = []
+        // replace object
+        await putIDBData(transaction, data)
+      }
     }
 
     stash.addEventListener('tagger:mutations:searchitems', checkSaveButtonDisplay);

--- a/src/header/Stash Batch Save.user.js
+++ b/src/header/Stash Batch Save.user.js
@@ -8,4 +8,4 @@
 // @grant       unsafeWindow
 // @require     %LIBRARYPATH%
 // @require     %FILEPATH%
-// ==/UserScript==o
+// ==/UserScript==

--- a/src/header/Stash Batch Save.user.js
+++ b/src/header/Stash Batch Save.user.js
@@ -2,10 +2,10 @@
 // @name        Stash Batch Save
 // @namespace   %NAMESPACE%
 // @description Adds a batch save button to scenes tagger
-// @version     0.5.2
+// @version     0.6.0
 // @author      7dJx1qP
 // @match       %MATCHURL%
 // @grant       unsafeWindow
 // @require     %LIBRARYPATH%
 // @require     %FILEPATH%
-// ==/UserScript==
+// ==/UserScript==o


### PR DESCRIPTION
The following PR removes the ability for batch saved scenes to submit fingerprints by

1. Hiding the "submit fingerprint" button
2. clearing the local fingerprintQueue value.

This persists until the next reload in which the fingerprint queue in react will also be cleared.